### PR TITLE
Unit tests for CrowdinProjectCacheProvider.getInstance()

### DIFF
--- a/src/main/java/com/crowdin/action/DownloadAction.java
+++ b/src/main/java/com/crowdin/action/DownloadAction.java
@@ -44,7 +44,7 @@ public class DownloadAction extends BackgroundAction {
             NotificationUtil.setLogDebugLevel(properties.isDebug());
             NotificationUtil.logDebugMessage(project, MESSAGES_BUNDLE.getString("messages.debug.started_action"));
 
-            Crowdin crowdin = new Crowdin(project, properties.getProjectId(), properties.getApiToken(), properties.getBaseUrl());
+            Crowdin crowdin = new Crowdin(properties.getProjectId(), properties.getApiToken(), properties.getBaseUrl());
 
             BranchLogic branchLogic = new BranchLogic(crowdin, project, properties);
             String branchName = branchLogic.acquireBranchName(true);

--- a/src/main/java/com/crowdin/action/DownloadSourceFromContextAction.java
+++ b/src/main/java/com/crowdin/action/DownloadSourceFromContextAction.java
@@ -54,7 +54,7 @@ public class DownloadSourceFromContextAction extends BackgroundAction {
             NotificationUtil.setLogDebugLevel(properties.isDebug());
             NotificationUtil.logDebugMessage(project, MESSAGES_BUNDLE.getString("messages.debug.started_action"));
 
-            Crowdin crowdin = new Crowdin(project, properties.getProjectId(), properties.getApiToken(), properties.getBaseUrl());
+            Crowdin crowdin = new Crowdin(properties.getProjectId(), properties.getApiToken(), properties.getBaseUrl());
             BranchLogic branchLogic = new BranchLogic(crowdin, project, properties);
             String branchName = branchLogic.acquireBranchName(true);
 

--- a/src/main/java/com/crowdin/action/DownloadSourcesAction.java
+++ b/src/main/java/com/crowdin/action/DownloadSourcesAction.java
@@ -64,7 +64,7 @@ public class DownloadSourcesAction extends BackgroundAction {
             NotificationUtil.setLogDebugLevel(properties.isDebug());
             NotificationUtil.logDebugMessage(project, MESSAGES_BUNDLE.getString("messages.debug.started_action"));
 
-            Crowdin crowdin = new Crowdin(project, properties.getProjectId(), properties.getApiToken(), properties.getBaseUrl());
+            Crowdin crowdin = new Crowdin(properties.getProjectId(), properties.getApiToken(), properties.getBaseUrl());
 
             BranchLogic branchLogic = new BranchLogic(crowdin, project, properties);
             String branchName = branchLogic.acquireBranchName(true);

--- a/src/main/java/com/crowdin/action/DownloadTranslationFromContextAction.java
+++ b/src/main/java/com/crowdin/action/DownloadTranslationFromContextAction.java
@@ -57,7 +57,7 @@ public class DownloadTranslationFromContextAction extends BackgroundAction {
             NotificationUtil.setLogDebugLevel(properties.isDebug());
             NotificationUtil.logDebugMessage(project, MESSAGES_BUNDLE.getString("messages.debug.started_action"));
 
-            Crowdin crowdin = new Crowdin(project, properties.getProjectId(), properties.getApiToken(), properties.getBaseUrl());
+            Crowdin crowdin = new Crowdin(properties.getProjectId(), properties.getApiToken(), properties.getBaseUrl());
 
             BranchLogic branchLogic = new BranchLogic(crowdin, project, properties);
             String branchName = branchLogic.acquireBranchName(true);
@@ -107,7 +107,7 @@ public class DownloadTranslationFromContextAction extends BackgroundAction {
             NotificationUtil.logDebugMessage(project, MESSAGES_BUNDLE.getString("messages.debug.started_action"));
 
             VirtualFile root = FileUtil.getProjectBaseDir(project);
-            Crowdin crowdin = new Crowdin(project, properties.getProjectId(), properties.getApiToken(), properties.getBaseUrl());
+            Crowdin crowdin = new Crowdin(properties.getProjectId(), properties.getApiToken(), properties.getBaseUrl());
 
             String branchName = ActionUtils.getBranchName(project, properties, false);
 

--- a/src/main/java/com/crowdin/action/UploadAction.java
+++ b/src/main/java/com/crowdin/action/UploadAction.java
@@ -41,7 +41,7 @@ public class UploadAction extends BackgroundAction {
             VirtualFile root = FileUtil.getProjectBaseDir(project);
 
             CrowdinProperties properties = CrowdinPropertiesLoader.load(project);
-            Crowdin crowdin = new Crowdin(project, properties.getProjectId(), properties.getApiToken(), properties.getBaseUrl());
+            Crowdin crowdin = new Crowdin(properties.getProjectId(), properties.getApiToken(), properties.getBaseUrl());
 
             NotificationUtil.setLogDebugLevel(properties.isDebug());
             NotificationUtil.logDebugMessage(project, MESSAGES_BUNDLE.getString("messages.debug.started_action"));

--- a/src/main/java/com/crowdin/action/UploadFromContextAction.java
+++ b/src/main/java/com/crowdin/action/UploadFromContextAction.java
@@ -18,7 +18,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 import static com.crowdin.Constants.MESSAGES_BUNDLE;
 
@@ -45,7 +44,7 @@ public class UploadFromContextAction extends BackgroundAction {
             NotificationUtil.setLogDebugLevel(properties.isDebug());
             NotificationUtil.logDebugMessage(project, MESSAGES_BUNDLE.getString("messages.debug.started_action"));
 
-            Crowdin crowdin = new Crowdin(project, properties.getProjectId(), properties.getApiToken(), properties.getBaseUrl());
+            Crowdin crowdin = new Crowdin(properties.getProjectId(), properties.getApiToken(), properties.getBaseUrl());
             BranchLogic branchLogic = new BranchLogic(crowdin, project, properties);
             String branchName = branchLogic.acquireBranchName(true);
             indicator.checkCanceled();

--- a/src/main/java/com/crowdin/action/UploadTranslationsAction.java
+++ b/src/main/java/com/crowdin/action/UploadTranslationsAction.java
@@ -47,7 +47,7 @@ public class UploadTranslationsAction extends BackgroundAction {
             NotificationUtil.setLogDebugLevel(properties.isDebug());
             NotificationUtil.logDebugMessage(project, MESSAGES_BUNDLE.getString("messages.debug.started_action"));
 
-            Crowdin crowdin = new Crowdin(project, properties.getProjectId(), properties.getApiToken(), properties.getBaseUrl());
+            Crowdin crowdin = new Crowdin(properties.getProjectId(), properties.getApiToken(), properties.getBaseUrl());
             indicator.checkCanceled();
 
             BranchLogic branchLogic = new BranchLogic(crowdin, project, properties);

--- a/src/main/java/com/crowdin/action/UploadTranslationsFromContextAction.java
+++ b/src/main/java/com/crowdin/action/UploadTranslationsFromContextAction.java
@@ -22,8 +22,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 
 import static com.crowdin.Constants.MESSAGES_BUNDLE;
@@ -49,7 +47,7 @@ public class UploadTranslationsFromContextAction extends BackgroundAction {
 
             VirtualFile root = FileUtil.getProjectBaseDir(project);
             CrowdinProperties properties = CrowdinPropertiesLoader.load(project);
-            Crowdin crowdin = new Crowdin(project, properties.getProjectId(), properties.getApiToken(), properties.getBaseUrl());
+            Crowdin crowdin = new Crowdin(properties.getProjectId(), properties.getApiToken(), properties.getBaseUrl());
 
             BranchLogic branchLogic = new BranchLogic(crowdin, project, properties);
             String branchName = branchLogic.acquireBranchName(true);
@@ -135,7 +133,7 @@ public class UploadTranslationsFromContextAction extends BackgroundAction {
             NotificationUtil.logDebugMessage(project, MESSAGES_BUNDLE.getString("messages.debug.started_action"));
 
             VirtualFile root = FileUtil.getProjectBaseDir(project);
-            Crowdin crowdin = new Crowdin(project, properties.getProjectId(), properties.getApiToken(), properties.getBaseUrl());
+            Crowdin crowdin = new Crowdin(properties.getProjectId(), properties.getApiToken(), properties.getBaseUrl());
 
             String branchName = ActionUtils.getBranchName(project, properties, false);
 

--- a/src/main/java/com/crowdin/activity/CrowdinStartupActivity.java
+++ b/src/main/java/com/crowdin/activity/CrowdinStartupActivity.java
@@ -6,7 +6,6 @@ import com.crowdin.client.CrowdinProperties;
 import com.crowdin.client.CrowdinPropertiesLoader;
 import com.crowdin.event.FileChangeListener;
 import com.crowdin.util.ActionUtils;
-import com.crowdin.util.GitUtil;
 import com.crowdin.util.NotificationUtil;
 import com.crowdin.util.PropertyUtil;
 import com.intellij.openapi.progress.ProgressIndicator;
@@ -28,7 +27,7 @@ public class CrowdinStartupActivity implements StartupActivity {
             }
             //config validation
             properties = CrowdinPropertiesLoader.load(project);
-            Crowdin crowdin = new Crowdin(project, properties.getProjectId(), properties.getApiToken(), properties.getBaseUrl());
+            Crowdin crowdin = new Crowdin(properties.getProjectId(), properties.getApiToken(), properties.getBaseUrl());
 
             String branchName = ActionUtils.getBranchName(project, properties, false);
 

--- a/src/main/java/com/crowdin/client/Crowdin.java
+++ b/src/main/java/com/crowdin/client/Crowdin.java
@@ -33,7 +33,7 @@ import java.util.stream.Collectors;
 
 import static com.crowdin.Constants.MESSAGES_BUNDLE;
 
-public class Crowdin {
+public class Crowdin implements CrowdinClient {
 
     private final Long projectId;
 
@@ -48,6 +48,7 @@ public class Crowdin {
         this.client = new Client(credentials, clientConfig);
     }
 
+    @Override
     public Long addStorage(String fileName, InputStream content) {
         return executeRequest(() -> this.client.getStorageApi()
             .addStorage(fileName, content)
@@ -55,72 +56,85 @@ public class Crowdin {
             .getId());
     }
 
+    @Override
     public void updateSource(Long sourceId, UpdateFileRequest request) {
         executeRequest(() -> this.client.getSourceFilesApi()
             .updateOrRestoreFile(this.projectId, sourceId, request));
     }
 
+    @Override
     public URL downloadFile(Long fileId) {
         return url(executeRequest(() -> this.client.getSourceFilesApi()
             .downloadFile(this.projectId, fileId)
             .getData()));
     }
 
+    @Override
     public void addSource(AddFileRequest request) {
         executeRequest(() -> this.client.getSourceFilesApi()
             .addFile(this.projectId, request));
     }
 
+    @Override
     public void editSource(Long fileId, List<PatchRequest> request) {
         executeRequest(() -> this.client.getSourceFilesApi()
             .editFile(this.projectId, fileId, request));
     }
 
+    @Override
     public void uploadTranslation(String languageId, UploadTranslationsRequest request) {
         executeRequest(() -> this.client.getTranslationsApi()
             .uploadTranslations(this.projectId, languageId, request));
     }
 
+    @Override
     public Directory addDirectory(AddDirectoryRequest request) {
         return executeRequest(() -> this.client.getSourceFilesApi()
             .addDirectory(this.projectId, request)
             .getData());
     }
 
+    @Override
     public com.crowdin.client.projectsgroups.model.Project getProject() {
         return executeRequest(() -> this.client.getProjectsGroupsApi()
             .getProject(this.projectId)
             .getData());
     }
 
+    @Override
     public List<Language> extractProjectLanguages(com.crowdin.client.projectsgroups.model.Project crowdinProject) {
         return crowdinProject.getTargetLanguages();
     }
 
+    @Override
     public ProjectBuild startBuildingTranslation(BuildProjectTranslationRequest request) {
         return executeRequest(() -> this.client.getTranslationsApi()
             .buildProjectTranslation(this.projectId, request)
             .getData());
     }
 
+    @Override
     public ProjectBuild checkBuildingStatus(Long buildId) {
         return executeRequest(() -> this.client.getTranslationsApi()
             .checkBuildStatus(projectId, buildId)
             .getData());
     }
 
+    @Override
     public URL downloadProjectTranslations(Long buildId) {
         return url(executeRequest(() -> this.client.getTranslationsApi()
             .downloadProjectTranslations(this.projectId, buildId)
             .getData()));
     }
 
+    @Override
     public URL downloadFileTranslation(Long fileId, BuildProjectFileTranslationRequest request) {
         return url(executeRequest(() -> client.getTranslationsApi()
             .buildProjectFileTranslation(this.projectId, fileId, null, request)
             .getData()));
     }
 
+    @Override
     public List<Language> getSupportedLanguages() {
         return executeRequest(() -> client.getLanguagesApi().listSupportedLanguages(500, 0)
             .getData()
@@ -129,6 +143,7 @@ public class Crowdin {
             .collect(Collectors.toList()));
     }
 
+    @Override
     public Map<Long, Directory> getDirectories(Long branchId) {
         return executeRequestFullList((limit, offset) ->
                 this.client.getSourceFilesApi()
@@ -141,6 +156,7 @@ public class Crowdin {
             .collect(Collectors.toMap(Directory::getId, Function.identity()));
     }
 
+    @Override
     public List<com.crowdin.client.sourcefiles.model.FileInfo> getFiles(Long branchId) {
         return executeRequestFullList((limit, offset) ->
                 this.client.getSourceFilesApi()
@@ -153,6 +169,7 @@ public class Crowdin {
             .collect(Collectors.toList());
     }
 
+    @Override
     public List<SourceString> getStrings() {
         return executeRequestFullList((limit, offset) ->
                 this.client.getSourceStringsApi().listSourceStrings(
@@ -188,6 +205,7 @@ public class Crowdin {
         return models;
     }
 
+    @Override
     public Branch addBranch(AddBranchRequest request) {
         try {
             return executeRequest(() -> this.client.getSourceFilesApi()
@@ -202,6 +220,7 @@ public class Crowdin {
         }
     }
 
+    @Override
     public Optional<Branch> getBranch(String name) {
         List<ResponseObject<Branch>> branches = executeRequest(() -> this.client.getSourceFilesApi().listBranches(this.projectId, name, 500, null).getData());
         return branches.stream()
@@ -210,6 +229,7 @@ public class Crowdin {
                 .findFirst();
     }
 
+    @Override
     public Map<String, Branch> getBranches() {
         return executeRequestFullList((limit, offset) ->
             this.client.getSourceFilesApi()
@@ -221,6 +241,7 @@ public class Crowdin {
             .collect(Collectors.toMap(Branch::getName, Function.identity()));
     }
 
+    @Override
     public List<LanguageProgress> getProjectProgress() {
         return executeRequestFullList((limit, offset) -> this.client.getTranslationStatusApi()
             .getProjectProgress(this.projectId, limit, offset, null)
@@ -230,6 +251,7 @@ public class Crowdin {
             .collect(Collectors.toList()));
     }
 
+    @Override
     public List<FileProgress> getLanguageProgress(String languageId) {
         return executeRequestFullList((limit, offset) -> this.client.getTranslationStatusApi()
             .getLanguageProgress(this.projectId, languageId, limit, offset)
@@ -239,6 +261,7 @@ public class Crowdin {
             .collect(Collectors.toList()));
     }
 
+    @Override
     public List<Label> listLabels() {
         return executeRequestFullList((limit, offset) -> this.client.getLabelsApi()
             .listLabels(this.projectId, limit, offset)
@@ -248,6 +271,7 @@ public class Crowdin {
             .collect(Collectors.toList()));
     }
 
+    @Override
     public Label addLabel(AddLabelRequest request) {
         return executeRequest(() ->this.client.getLabelsApi()
             .addLabel(this.projectId, request)

--- a/src/main/java/com/crowdin/client/Crowdin.java
+++ b/src/main/java/com/crowdin/client/Crowdin.java
@@ -16,7 +16,6 @@ import com.crowdin.client.translationstatus.model.FileProgress;
 import com.crowdin.client.translationstatus.model.LanguageProgress;
 import com.crowdin.util.RetryUtil;
 import com.crowdin.util.Util;
-import com.intellij.openapi.project.Project;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
@@ -38,12 +37,9 @@ public class Crowdin {
 
     private final Long projectId;
 
-    private final Project project;
-
     private final com.crowdin.client.Client client;
 
-    public Crowdin(@NotNull Project project, @NotNull Long projectId, @NotNull String apiToken, String baseUrl) {
-        this.project = project;
+    public Crowdin(@NotNull Long projectId, @NotNull String apiToken, String baseUrl) {
         this.projectId = projectId;
         Credentials credentials = new Credentials(apiToken, null, baseUrl);
         ClientConfig clientConfig = ClientConfig.builder()

--- a/src/main/java/com/crowdin/client/CrowdinClient.java
+++ b/src/main/java/com/crowdin/client/CrowdinClient.java
@@ -1,0 +1,81 @@
+package com.crowdin.client;
+
+import com.crowdin.client.core.model.PatchRequest;
+import com.crowdin.client.labels.model.AddLabelRequest;
+import com.crowdin.client.labels.model.Label;
+import com.crowdin.client.languages.model.Language;
+import com.crowdin.client.projectsgroups.model.Project;
+import com.crowdin.client.sourcefiles.model.AddBranchRequest;
+import com.crowdin.client.sourcefiles.model.AddDirectoryRequest;
+import com.crowdin.client.sourcefiles.model.AddFileRequest;
+import com.crowdin.client.sourcefiles.model.Branch;
+import com.crowdin.client.sourcefiles.model.Directory;
+import com.crowdin.client.sourcefiles.model.FileInfo;
+import com.crowdin.client.sourcefiles.model.UpdateFileRequest;
+import com.crowdin.client.sourcestrings.model.SourceString;
+import com.crowdin.client.translations.model.BuildProjectFileTranslationRequest;
+import com.crowdin.client.translations.model.BuildProjectTranslationRequest;
+import com.crowdin.client.translations.model.ProjectBuild;
+import com.crowdin.client.translations.model.UploadTranslationsRequest;
+import com.crowdin.client.translationstatus.model.FileProgress;
+import com.crowdin.client.translationstatus.model.LanguageProgress;
+
+import java.io.InputStream;
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Base type for a Crowdin client.
+ */
+public interface CrowdinClient {
+
+    Long addStorage(String fileName, InputStream content);
+
+    void updateSource(Long sourceId, UpdateFileRequest request);
+
+    URL downloadFile(Long fileId);
+
+    void addSource(AddFileRequest request);
+
+    void editSource(Long fileId, List<PatchRequest> request);
+
+    void uploadTranslation(String languageId, UploadTranslationsRequest request);
+
+    Directory addDirectory(AddDirectoryRequest request);
+
+    Project getProject();
+
+    List<Language> extractProjectLanguages(Project crowdinProject);
+
+    ProjectBuild startBuildingTranslation(BuildProjectTranslationRequest request);
+
+    ProjectBuild checkBuildingStatus(Long buildId);
+
+    URL downloadProjectTranslations(Long buildId);
+
+    URL downloadFileTranslation(Long fileId, BuildProjectFileTranslationRequest request);
+
+    List<Language> getSupportedLanguages();
+
+    Map<Long, Directory> getDirectories(Long branchId);
+
+    List<FileInfo> getFiles(Long branchId);
+
+    List<SourceString> getStrings();
+
+    Branch addBranch(AddBranchRequest request);
+
+    Optional<Branch> getBranch(String name);
+
+    Map<String, Branch> getBranches();
+
+    List<LanguageProgress> getProjectProgress();
+
+    List<FileProgress> getLanguageProgress(String languageId);
+
+    List<Label> listLabels();
+
+    Label addLabel(AddLabelRequest request);
+}

--- a/src/main/java/com/crowdin/completion/StringsCompletionContributor.java
+++ b/src/main/java/com/crowdin/completion/StringsCompletionContributor.java
@@ -58,7 +58,7 @@ public class StringsCompletionContributor extends CompletionContributor {
             return;
         }
 
-        Crowdin crowdin = new Crowdin(project, properties.getProjectId(), properties.getApiToken(), properties.getBaseUrl());
+        Crowdin crowdin = new Crowdin(properties.getProjectId(), properties.getApiToken(), properties.getBaseUrl());
 
         BranchLogic branchLogic = new BranchLogic(crowdin, project, properties);
         String branchName = branchLogic.acquireBranchName(true);

--- a/src/main/java/com/crowdin/event/FileChangeListener.java
+++ b/src/main/java/com/crowdin/event/FileChangeListener.java
@@ -1,7 +1,6 @@
 package com.crowdin.event;
 
 import com.crowdin.client.*;
-import com.crowdin.client.sourcefiles.model.AddBranchRequest;
 import com.crowdin.client.sourcefiles.model.Branch;
 import com.crowdin.logic.BranchLogic;
 import com.crowdin.logic.SourceLogic;
@@ -19,7 +18,6 @@ import com.intellij.openapi.vfs.VirtualFileManager;
 import com.intellij.openapi.vfs.newvfs.BulkFileListener;
 import com.intellij.openapi.vfs.newvfs.events.VFileEvent;
 import com.intellij.util.messages.MessageBusConnection;
-import org.apache.commons.lang.StringUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
@@ -71,7 +69,7 @@ public class FileChangeListener implements Disposable, BulkFileListener {
                         return;
                     }
                     indicator.checkCanceled();
-                    Crowdin crowdin = new Crowdin(project, properties.getProjectId(), properties.getApiToken(), properties.getBaseUrl());
+                    Crowdin crowdin = new Crowdin(properties.getProjectId(), properties.getApiToken(), properties.getBaseUrl());
 
                     BranchLogic branchLogic = new BranchLogic(crowdin, project, properties);
                     String branchName = branchLogic.acquireBranchName(true);

--- a/src/main/java/com/crowdin/ui/action/RefreshTranslationProgressAction.java
+++ b/src/main/java/com/crowdin/ui/action/RefreshTranslationProgressAction.java
@@ -13,9 +13,7 @@ import com.crowdin.client.translationstatus.model.LanguageProgress;
 import com.crowdin.ui.TranslationProgressWindow;
 import com.crowdin.ui.TranslationProgressWindowFactory;
 import com.crowdin.util.ActionUtils;
-import com.crowdin.util.CrowdinFileUtil;
 import com.crowdin.util.FileUtil;
-import com.crowdin.util.GitUtil;
 import com.crowdin.util.NotificationUtil;
 import com.intellij.icons.AllIcons;
 import com.intellij.openapi.actionSystem.AnActionEvent;
@@ -71,7 +69,7 @@ public class RefreshTranslationProgressAction extends BackgroundAction {
             VirtualFile root = FileUtil.getProjectBaseDir(project);
 
             CrowdinProperties properties = CrowdinPropertiesLoader.load(project);
-            Crowdin crowdin = new Crowdin(project, properties.getProjectId(), properties.getApiToken(), properties.getBaseUrl());
+            Crowdin crowdin = new Crowdin(properties.getProjectId(), properties.getApiToken(), properties.getBaseUrl());
 
             NotificationUtil.setLogDebugLevel(properties.isDebug());
             NotificationUtil.logDebugMessage(project, MESSAGES_BUNDLE.getString("messages.debug.started_action"));

--- a/src/test/java/com/crowdin/client/CrowdinProjectCacheProviderTest.java
+++ b/src/test/java/com/crowdin/client/CrowdinProjectCacheProviderTest.java
@@ -1,30 +1,49 @@
 package com.crowdin.client;
 
+import com.crowdin.client.CrowdinProjectCacheProvider.CrowdinProjectCache;
+import com.crowdin.client.projectsgroups.model.Project;
+import com.crowdin.client.projectsgroups.model.ProjectSettings;
 import com.crowdin.client.sourcefiles.model.Branch;
+import com.crowdin.client.sourcefiles.model.Directory;
 import com.crowdin.client.sourcefiles.model.File;
 import com.crowdin.client.sourcefiles.model.FileInfo;
 import com.crowdin.util.LanguageMapping;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Stream;
 
-import static org.junit.Assert.assertEquals;
+import static com.crowdin.client.MockCrowdin.STANDARD_BRANCH_1;
+import static com.crowdin.client.MockCrowdin.STANDARD_BRANCH_2;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 
 public class CrowdinProjectCacheProviderTest {
 
+    @BeforeEach
+    void setUp() {
+        CrowdinProjectCacheProvider.reset();
+    }
+
     @ParameterizedTest
     @MethodSource
     public void testGetFileInfos(final Map<Branch, Map<String, ? extends FileInfo>> fileInfo,
                                  final Branch branch, final Map<String, FileInfo> expected) {
-        CrowdinProjectCacheProvider.CrowdinProjectCache cache = new CrowdinProjectCacheProvider.CrowdinProjectCache();
+        CrowdinProjectCache cache = new CrowdinProjectCache();
         cache.setFileInfos(fileInfo);
         final Map<String, FileInfo> result = cache.getFileInfos(branch);
         assertEquals(expected, result);
@@ -49,7 +68,7 @@ public class CrowdinProjectCacheProviderTest {
     @MethodSource
     public void testGetFiles(final Map<Branch, Map<String, ? extends FileInfo>> fileInfo,
                                  final Branch branch, final Map<String, File> expected) {
-        CrowdinProjectCacheProvider.CrowdinProjectCache cache = new CrowdinProjectCacheProvider.CrowdinProjectCache();
+        CrowdinProjectCache cache = new CrowdinProjectCache();
         cache.setFileInfos(fileInfo);
         cache.setManagerAccess(true);
         final Map<String, File> result = cache.getFiles(branch);
@@ -74,7 +93,7 @@ public class CrowdinProjectCacheProviderTest {
     @ParameterizedTest
     @MethodSource
     public void testGetLanguageMapping(final LanguageMapping mapping, final LanguageMapping expected) {
-        CrowdinProjectCacheProvider.CrowdinProjectCache cache = new CrowdinProjectCacheProvider.CrowdinProjectCache();
+        CrowdinProjectCache cache = new CrowdinProjectCache();
         cache.setLanguageMapping(mapping);
         cache.setManagerAccess(true);
         final LanguageMapping result = cache.getLanguageMapping();
@@ -89,7 +108,7 @@ public class CrowdinProjectCacheProviderTest {
     @ParameterizedTest
     @MethodSource
     public void testRunTimeException(final LanguageMapping mapping) {
-        CrowdinProjectCacheProvider.CrowdinProjectCache cache = new CrowdinProjectCacheProvider.CrowdinProjectCache();
+        CrowdinProjectCache cache = new CrowdinProjectCache();
         cache.setManagerAccess(false);
         cache.setLanguageMapping(mapping);
         assertThrows(RuntimeException.class, cache::getLanguageMapping);
@@ -103,10 +122,259 @@ public class CrowdinProjectCacheProviderTest {
     @ParameterizedTest
     @MethodSource
     public void testAddOutdatedBranch(final String branchName) {
-        assertDoesNotThrow(() ->CrowdinProjectCacheProvider.outdateBranch(branchName));
+        assertDoesNotThrow(() -> CrowdinProjectCacheProvider.outdateBranch(branchName));
     }
 
     private static Stream<Arguments> testAddOutdatedBranch() {
         return Stream.of(arguments("branchName"));
+    }
+
+    //getInstance()
+
+    @Test
+    void testSetsValuesForNotYetConfiguredCacheProperties() {
+        CrowdinClient crowdin = new MockCrowdin(1L);
+        //Using a different branch name than what's in MockCrowdin, so that fileinfos doesn't get updated
+        CrowdinProjectCache cache = CrowdinProjectCacheProvider.getInstance(crowdin, "branchname", false);
+
+        assertEquals(crowdin.getProject(), cache.getProject());
+        assertFalse(cache.isManagerAccess());
+        assertEquals(crowdin.getStrings(), cache.getStrings());
+        assertEquals(crowdin.getSupportedLanguages(), cache.getSupportedLanguages());
+        assertEquals(crowdin.extractProjectLanguages(crowdin.getProject()), cache.getProjectLanguages());
+        assertEquals(crowdin.getBranches(), cache.getBranches());
+
+        assertNotNull(cache.getFileInfos());
+        assertEquals(0, cache.getFileInfos().size());
+
+        assertNotNull(cache.getDirs());
+        assertEquals(0, cache.getDirs().size());
+    }
+
+    @Test
+    void testDoesntSetConfigurationForExistingValues() {
+        //Set the initial state of the underlying project cache. Using empty collections to have simpler test data.
+        CrowdinProjectCache cache = new CrowdinProjectCache();
+        CrowdinProjectCacheProvider.setCrowdinProjectCache(cache);
+
+        Project project = new Project();
+        cache.setProject(project);
+        cache.setManagerAccess(false);
+        cache.setStrings(new ArrayList<>());
+        cache.setSupportedLanguages(new ArrayList<>());
+        cache.setProjectLanguages(new ArrayList<>());
+        cache.setBranches(new HashMap<>());
+
+        //File infos and dirs are initialized to non-empty collections here,
+        // because they are initialized as empty collections in getInstance(),
+        // so we can properly see a failure if that occurs.
+        Map<Branch, Map<String, ? extends FileInfo>> fileInfos = createFileInfos(STANDARD_BRANCH_1, new HashMap<>());
+        cache.setFileInfos(fileInfos);
+
+        Map<Branch, Map<String, Directory>> dirs = createDirs(STANDARD_BRANCH_1, new HashMap<>());
+        cache.setDirs(dirs);
+
+        CrowdinClient crowdin = new MockCrowdin(1L);
+        cache = CrowdinProjectCacheProvider.getInstance(crowdin, "branch1", false);
+
+        //Validating 0 collection sizes is feasible because we presume
+        // that the used MockCrowdin instance returns non-empty collections
+        assertSame(project, cache.getProject());
+        assertFalse(cache.isManagerAccess());
+        assertEquals(0, cache.getStrings().size());
+        assertEquals(0, cache.getSupportedLanguages().size());
+        assertEquals(0, cache.getProjectLanguages().size());
+        assertEquals(0, cache.getBranches().size());
+        assertEquals(fileInfos, cache.getFileInfos());
+        assertEquals(dirs, cache.getDirs());
+    }
+
+    @Test
+    void testSetsLanguageMappingForManagerAccess() {
+        CrowdinClient crowdin = new MockCrowdin(2L);
+        CrowdinProjectCache cache = CrowdinProjectCacheProvider.getInstance(crowdin, "branch1", false);
+
+        assertTrue(cache.isManagerAccess());
+        assertTrue(cache.getLanguageMapping().containsValue("hu", "placeholder"));
+    }
+
+    @Test
+    void testSetsBranchesWhenOutdated() {
+        CrowdinProjectCache cache = new CrowdinProjectCache();
+        CrowdinProjectCacheProvider.setCrowdinProjectCache(cache);
+        cache.setBranches(new HashMap<>());
+        CrowdinProjectCacheProvider.outdateBranch("branch1");
+
+        CrowdinClient crowdin = new MockCrowdin(1L);
+        cache = CrowdinProjectCacheProvider.getInstance(crowdin, "branch1", false);
+
+        assertEquals(crowdin.getBranches(), cache.getBranches());
+    }
+
+    @Test
+    void testDoesntSetConfigurationForNoUpdate() {
+        //Set the initial state of the underlying project cache. Using empty collections to have simpler test data.
+        CrowdinProjectCache cache = new CrowdinProjectCache();
+        CrowdinProjectCacheProvider.setCrowdinProjectCache(cache);
+
+        //Using ProjectSettings because that would set manager access to true,
+        // thus we can validate if it remains false
+        Project project = new ProjectSettings();
+        cache.setProject(project);
+        cache.setProjectLanguages(new ArrayList<>());
+        cache.setBranches(new HashMap<>());
+
+        CrowdinClient crowdin = new MockCrowdin(1L);
+        cache = CrowdinProjectCacheProvider.getInstance(crowdin, "branch1", false);
+
+        //Test that no configuration was overwritten with data from the mock Crowdin client
+        assertSame(project, cache.getProject());
+        assertFalse(cache.isManagerAccess());
+        assertEquals(0, cache.getProjectLanguages().size());
+        assertEquals(0, cache.getBranches().size());
+    }
+
+    @Test
+    void testSetsConfigurationForUpdate() {
+        //Set the initial state of the underlying project cache. Using empty collections to have simpler test data.
+        CrowdinProjectCache cache = new CrowdinProjectCache();
+        CrowdinProjectCacheProvider.setCrowdinProjectCache(cache);
+
+        //Using ProjectSettings because that would set manager access to true,
+        // thus we can validate if it remains false.
+        Project project = new ProjectSettings();
+        cache.setProject(project);
+        cache.setProjectLanguages(new ArrayList<>());
+        cache.setBranches(new HashMap<>());
+
+        CrowdinClient crowdin = new MockCrowdin(1L);
+        cache = CrowdinProjectCacheProvider.getInstance(crowdin, "branch1", true);
+
+        //Test that no configuration was overwritten with data from the mock Crowdin client
+        assertSame(crowdin.getProject(), cache.getProject());
+        assertFalse(cache.isManagerAccess()); //false because using project id 1L
+        assertEquals(crowdin.extractProjectLanguages(crowdin.getProject()), cache.getProjectLanguages());
+        assertEquals(crowdin.getBranches(), cache.getBranches());
+    }
+
+    //getInstance() - update file infos and dirs for branch
+
+    @Test
+    void testSavesBranchWhenFileInfosDoesntContainBranch() {
+        CrowdinProjectCache cache = new CrowdinProjectCache();
+        CrowdinProjectCacheProvider.setCrowdinProjectCache(cache);
+
+        CrowdinClient crowdin = new MockCrowdin(1L);
+        cache.setBranches(crowdin.getBranches());
+        //FileInfos doesn't contain branch2
+        cache.setFileInfos(createFileInfos(STANDARD_BRANCH_1, new HashMap<>()));
+
+        CrowdinProjectCacheProvider.outdateBranch("branch2");
+
+        cache = CrowdinProjectCacheProvider.getInstance(crowdin, "branch2", false);
+
+        assertTrue(cache.getFileInfos().containsKey(STANDARD_BRANCH_2));
+        assertTrue(cache.getDirs().containsKey(STANDARD_BRANCH_2));
+        assertFalse(CrowdinProjectCacheProvider.getOutdatedBranches().contains("branch2"));
+    }
+
+    @Test
+    void testSavesBranchWhenDirsDoesntContainBranch() {
+        CrowdinProjectCache cache = new CrowdinProjectCache();
+        CrowdinProjectCacheProvider.setCrowdinProjectCache(cache);
+
+        CrowdinClient crowdin = new MockCrowdin(1L);
+        cache.setBranches(crowdin.getBranches());
+        //FileInfos contains branch2, Dirs doesn't contain branch2
+        HashMap<String, FileInfo> fileInfoValue = new HashMap<>();
+        cache.setFileInfos(createFileInfos(STANDARD_BRANCH_2, fileInfoValue));
+        cache.setDirs(createDirs(STANDARD_BRANCH_1, new HashMap<>()));
+
+        CrowdinProjectCacheProvider.outdateBranch("branch2");
+
+        cache = CrowdinProjectCacheProvider.getInstance(crowdin, "branch2", false);
+
+        //Validate if fileinfos branch entry value is updated
+        assertNotSame(fileInfoValue, cache.getFileInfos().get(STANDARD_BRANCH_2));
+        assertTrue(cache.getDirs().containsKey(STANDARD_BRANCH_2));
+        assertFalse(CrowdinProjectCacheProvider.getOutdatedBranches().contains("branch2"));
+    }
+
+    @Test
+    void testSavesBranchWhenBranchIsOutdated() {
+        CrowdinProjectCache cache = new CrowdinProjectCache();
+        CrowdinProjectCacheProvider.setCrowdinProjectCache(cache);
+
+        CrowdinClient crowdin = new MockCrowdin(1L);
+        cache.setBranches(crowdin.getBranches());
+        //FileInfos and dirs both contain branch2
+        HashMap<String, FileInfo> fileInfoValue = new HashMap<>();
+        cache.setFileInfos(createFileInfos(STANDARD_BRANCH_2, fileInfoValue));
+        HashMap<String, Directory> dirsValue = new HashMap<>();
+        cache.setDirs(createDirs(STANDARD_BRANCH_2, dirsValue));
+
+        CrowdinProjectCacheProvider.outdateBranch("branch2");
+
+        cache = CrowdinProjectCacheProvider.getInstance(crowdin, "branch2", false);
+
+        //Validate if fileinfos and dirs branch entry values are updated
+        assertNotSame(fileInfoValue, cache.getFileInfos().get(STANDARD_BRANCH_2));
+        assertNotSame(dirsValue, cache.getDirs().get(STANDARD_BRANCH_2));
+        assertFalse(CrowdinProjectCacheProvider.getOutdatedBranches().contains("branch2"));
+    }
+
+    @Test
+    void testSavesBranchWhenMarkedForUpdate() {
+        CrowdinProjectCache cache = new CrowdinProjectCache();
+        CrowdinProjectCacheProvider.setCrowdinProjectCache(cache);
+
+        CrowdinClient crowdin = new MockCrowdin(1L);
+        cache.setBranches(crowdin.getBranches());
+        //FileInfos and dirs both contain branch2
+        HashMap<String, FileInfo> fileInfoValue = new HashMap<>();
+        cache.setFileInfos(createFileInfos(STANDARD_BRANCH_2, fileInfoValue));
+        HashMap<String, Directory> dirsValue = new HashMap<>();
+        cache.setDirs(createDirs(STANDARD_BRANCH_2, dirsValue));
+
+        cache = CrowdinProjectCacheProvider.getInstance(crowdin, "branch2", true);
+
+        //Validate if fileinfos and dirs branch entry values are updated
+        assertNotSame(fileInfoValue, cache.getFileInfos().get(STANDARD_BRANCH_2));
+        assertNotSame(dirsValue, cache.getDirs().get(STANDARD_BRANCH_2));
+        assertFalse(CrowdinProjectCacheProvider.getOutdatedBranches().contains("branch2"));
+    }
+
+    @Test
+    void testDoesntSaveBranch() {
+        CrowdinProjectCache cache = new CrowdinProjectCache();
+        CrowdinProjectCacheProvider.setCrowdinProjectCache(cache);
+
+        CrowdinClient crowdin = new MockCrowdin(1L);
+        cache.setBranches(crowdin.getBranches());
+        //FileInfos and dirs both contain branch2
+        HashMap<String, FileInfo> fileInfoValue = new HashMap<>();
+        cache.setFileInfos(createFileInfos(STANDARD_BRANCH_2, fileInfoValue));
+        HashMap<String, Directory> dirsValue = new HashMap<>();
+        cache.setDirs(createDirs(STANDARD_BRANCH_2, dirsValue));
+
+        cache = CrowdinProjectCacheProvider.getInstance(crowdin, "branch2", false);
+
+        //Validate if fileinfos and dirs branch entry values are updated
+        assertSame(fileInfoValue, cache.getFileInfos().get(STANDARD_BRANCH_2));
+        assertSame(dirsValue, cache.getDirs().get(STANDARD_BRANCH_2));
+    }
+
+    //Helper methods
+
+    private Map<Branch, Map<String, ? extends FileInfo>> createFileInfos(Branch key, Map<String, ? extends FileInfo> value) {
+        Map<Branch, Map<String, ? extends FileInfo>> map = new HashMap<>();
+        map.put(key, value);
+        return map;
+    }
+
+    private Map<Branch, Map<String, Directory>> createDirs(Branch key, Map<String, Directory> value) {
+        Map<Branch, Map<String, Directory>> map = new HashMap<>();
+        map.put(key, value);
+        return map;
     }
 }

--- a/src/test/java/com/crowdin/client/MockCrowdin.java
+++ b/src/test/java/com/crowdin/client/MockCrowdin.java
@@ -1,0 +1,179 @@
+package com.crowdin.client;
+
+import static java.util.Collections.singletonMap;
+
+import com.crowdin.api.model.BranchBuilder;
+import com.crowdin.api.model.LanguageBuilder;
+import com.crowdin.client.core.model.PatchRequest;
+import com.crowdin.client.labels.model.AddLabelRequest;
+import com.crowdin.client.labels.model.Label;
+import com.crowdin.client.languages.model.Language;
+import com.crowdin.client.projectsgroups.model.Project;
+import com.crowdin.client.projectsgroups.model.ProjectSettings;
+import com.crowdin.client.sourcefiles.model.AddBranchRequest;
+import com.crowdin.client.sourcefiles.model.AddDirectoryRequest;
+import com.crowdin.client.sourcefiles.model.AddFileRequest;
+import com.crowdin.client.sourcefiles.model.Branch;
+import com.crowdin.client.sourcefiles.model.Directory;
+import com.crowdin.client.sourcefiles.model.FileInfo;
+import com.crowdin.client.sourcefiles.model.UpdateFileRequest;
+import com.crowdin.client.sourcestrings.model.SourceString;
+import com.crowdin.client.translations.model.BuildProjectFileTranslationRequest;
+import com.crowdin.client.translations.model.BuildProjectTranslationRequest;
+import com.crowdin.client.translations.model.ProjectBuild;
+import com.crowdin.client.translations.model.UploadTranslationsRequest;
+import com.crowdin.client.translationstatus.model.FileProgress;
+import com.crowdin.client.translationstatus.model.LanguageProgress;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Mock Crowdin client for testing purposes, so that real HTTP requests are not sent to Crowdin.
+ */
+public class MockCrowdin implements CrowdinClient {
+
+    static final Branch STANDARD_BRANCH_1 = BranchBuilder.standard().setIdentifiers("branch1", 1L).build();
+    static final Branch STANDARD_BRANCH_2 = BranchBuilder.standard().setIdentifiers("branch2", 2L).build();
+
+    private final Project project;
+
+    public MockCrowdin(@NotNull Long projectId) {
+        if (projectId == 2L) {
+            ProjectSettings projectSettings = new ProjectSettings();
+            projectSettings.setLanguageMapping(singletonMap("hu", singletonMap("placeholder", "value")));
+            project = projectSettings;
+        } else {
+            project = new Project();
+        }
+    }
+
+    @Override
+    public Long addStorage(String fileName, InputStream content) {
+        return null;
+    }
+
+    @Override
+    public void updateSource(Long sourceId, UpdateFileRequest request) {
+    }
+
+    @Override
+    public URL downloadFile(Long fileId) {
+        return null;
+    }
+
+    @Override
+    public void addSource(AddFileRequest request) {
+    }
+
+    @Override
+    public void editSource(Long fileId, List<PatchRequest> request) {
+    }
+
+    @Override
+    public void uploadTranslation(String languageId, UploadTranslationsRequest request) {
+    }
+
+    @Override
+    public Directory addDirectory(AddDirectoryRequest request) {
+        return null;
+    }
+
+    @Override
+    public Project getProject() {
+        return project;
+    }
+
+    @Override
+    public List<Language> extractProjectLanguages(Project crowdinProject) {
+        return Collections.singletonList(LanguageBuilder.DEU.build());
+    }
+
+    @Override
+    public ProjectBuild startBuildingTranslation(BuildProjectTranslationRequest request) {
+        return null;
+    }
+
+    @Override
+    public ProjectBuild checkBuildingStatus(Long buildId) {
+        return null;
+    }
+
+    @Override
+    public URL downloadProjectTranslations(Long buildId) {
+        return null;
+    }
+
+    @Override
+    public URL downloadFileTranslation(Long fileId, BuildProjectFileTranslationRequest request) {
+        return null;
+    }
+
+    @Override
+    public List<Language> getSupportedLanguages() {
+        return Collections.singletonList(LanguageBuilder.ENG.build());
+    }
+
+    @Override
+    public Map<Long, Directory> getDirectories(Long branchId) {
+        Directory dir = new Directory();
+        dir.setName("dirname");
+        return singletonMap(10L, dir);
+    }
+
+    @Override
+    public List<FileInfo> getFiles(Long branchId) {
+        FileInfo fileInfo = new FileInfo();
+        fileInfo.setName("filename");
+        return Collections.singletonList(fileInfo);
+    }
+
+    @Override
+    public List<SourceString> getStrings() {
+        return Collections.singletonList(new SourceString());
+    }
+
+    @Override
+    public Branch addBranch(AddBranchRequest request) {
+        return null;
+    }
+
+    @Override
+    public Optional<Branch> getBranch(String name) {
+        return Optional.empty();
+    }
+
+    @Override
+    public Map<String, Branch> getBranches() {
+        Map<String, Branch> branches = new HashMap<>();
+        branches.put("branch1", STANDARD_BRANCH_1);
+        branches.put("branch2", STANDARD_BRANCH_2);
+        return branches;
+    }
+
+    @Override
+    public List<LanguageProgress> getProjectProgress() {
+        return null;
+    }
+
+    @Override
+    public List<FileProgress> getLanguageProgress(String languageId) {
+        return null;
+    }
+
+    @Override
+    public List<Label> listLabels() {
+        return null;
+    }
+
+    @Override
+    public Label addLabel(AddLabelRequest request) {
+        return null;
+    }
+}


### PR DESCRIPTION
### Changes
- Introduced the `CrowdinClient` type along with its `MockCrowdin` implementation for tests, so that unit tests don't have to send real HTTP requests to Crowdin.
- Removed the unused `Project` constructor argument and field of `Crowdin`.
  - This was supposed to simplify unit testing for `getInstance()` before `MockCrowdin` were introduced, but kept the changes because it was unused anyway.
- Added unit tests for `CrowdinProjectCacheProvider.getInstance()`.